### PR TITLE
GOP-1662: define scala-parser-combinators dep as api (transitive)

### DIFF
--- a/gortools/build.gradle
+++ b/gortools/build.gradle
@@ -39,11 +39,13 @@ project(':gortools') {
         implementation project(':base')
         implementation project(':util')
 
+        // scala-parser-combinators must be present at compile time for callers so it's defined as an api dependency
+        api "org.scala-lang.modules:scala-parser-combinators_2.12:1.0.+"
+
         implementation "org.freemarker:freemarker:2.3.19"
         implementation "org.yaml:snakeyaml:1.25"
         implementation "org.scala-lang:scala-compiler:2.12.+"
         implementation "com.fasterxml.jackson.core:jackson-databind:2.11.+"
-        implementation "org.scala-lang.modules:scala-parser-combinators_2.12:1.0.+"
         implementation "org.scalanlp:breeze_2.12:0.13.+"
         implementation "info.picocli:picocli:4.1.+"
         implementation "de.tototec:de.tototec.cmdoption:0.6.+"

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -33,13 +33,15 @@ project(':model') {
         implementation project(':base')
         implementation project(':util')
 
+        // scala-parser-combinators must be present at compile time for callers so it's defined as an api dependency
+        api "org.scala-lang.modules:scala-parser-combinators_2.12:1.0.+"
+
         annotationProcessor 'com.google.auto.service:auto-service:1.0-rc6'
         implementation 'com.google.auto.service:auto-service:1.0-rc6'
         implementation "org.aeonbits.owner:owner:1.0.+"
         implementation "commons-configuration:commons-configuration:1.10"
         implementation "com.github.samtools:htsjdk:2.22.+"
         implementation "com.github.luben:zstd-jni:1.4.4-3"  // TODO: 1.4.4.4-5 seems to be broken - fix zstd-jni at an earlier version for now
-        implementation("org.scala-lang.modules:scala-parser-combinators_2.12:1.0.7")
         implementation "com.zaxxer:HikariCP:3.4.+"
         implementation "com.fasterxml.jackson.core:jackson-databind:2.11.+"
         implementation 'org.apache.parquet:parquet-common:1.11.0'


### PR DESCRIPTION
This changes the definition of scala-parser-combinators from "implementation" to "api" to force it as a transitive compile time dependency to users of the libraries.

The rationale is that users of gortools for example, will not necessarily be using the API of scala-parser-combinators directly and so they should not declare a direct dependency from their projects. However, their project will not compile when they declare a dependency on gortools only. Therefore, the scala-parser-combinators should come as a transitive dependency ("api") even though the callers won't directly use the API of scala-parser-combinators.