### PR TITLE
Tests data submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/data"]
 	path = tests/data
-	url = ../gor-test-data
+	url = https://github.com/gorpipe/gor-test-data.git


### PR DESCRIPTION
Two small changes.
* Full submodule URL. Using the relative URL doesn't work in forks.
* Pointing the submodule commit to the master HEAD. Not sure how the missing commit SHA was introduced. Maybe a repository move?

Fixes error:
```shell
❯ git submodule update --init --recursive
Submodule 'tests/data' (https://github.com/gorpipe/gor-test-data.git) registered for path 'tests/data'
Cloning into '/Users/cborroto/Projects/gor/tests/data'...
fatal: remote error: upload-pack: not our ref 3f72499be2141dc112f957993a0b123bc280c222
fatal: Fetched in submodule path 'tests/data', but it did not contain 3f72499be2141dc112f957993a0b123bc280c222. Direct fetching of that commit failed.
```