### PR TITLE
fix(ENGKNOW-2005): Fix threadlimit exceeded error when seeking in Gor

### DIFF
--- a/base/src/main/java/org/gorpipe/base/concurrency/CommonThreadPools.java
+++ b/base/src/main/java/org/gorpipe/base/concurrency/CommonThreadPools.java
@@ -1,0 +1,21 @@
+package org.gorpipe.base.concurrency;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+
+public class CommonThreadPools {
+
+    // See: java/util/concurrent/ForkJoinPool.java
+    public static final ForkJoinPool seekThreadPool = new ForkJoinPool(
+            Runtime.getRuntime().availableProcessors(),  // Same as default.
+            ForkJoinPool.defaultForkJoinWorkerThreadFactory,  // Same as default.
+            null,  // Same as default.
+            false,  // Same as default.
+            16,  // Defaults to the same as parallelism.
+            256,  // Same as default.
+            1,  // Same as default.
+            p -> true,  // Set to true, so we don't throw error if pool exhausted, instead we wait.
+            60,        // Same as default
+            TimeUnit.SECONDS);      // Same as default
+
+}

--- a/model/src/main/java/org/gorpipe/gor/driver/providers/stream/sources/file/FileSource.java
+++ b/model/src/main/java/org/gorpipe/gor/driver/providers/stream/sources/file/FileSource.java
@@ -294,6 +294,10 @@ public class FileSource implements StreamSource {
     @Override
     public Stream<String> list()  {
         try {
+            // Force meta data update on the parent.
+            try (Stream<Path> paths = Files.list(filePath.getParent())) {
+                // Intentionally empty.
+            }
             return mapPathToRelative(Files.list(filePath));
         } catch (IOException e) {
             throw GorResourceException.fromIOException(e, getPath()).retry();

--- a/model/src/main/java/org/gorpipe/gor/driver/providers/stream/sources/file/FileSource.java
+++ b/model/src/main/java/org/gorpipe/gor/driver/providers/stream/sources/file/FileSource.java
@@ -294,10 +294,6 @@ public class FileSource implements StreamSource {
     @Override
     public Stream<String> list()  {
         try {
-            // Force meta data update on the parent.
-            try (Stream<Path> paths = Files.list(filePath.getParent())) {
-                // Intentionally empty.
-            }
             return mapPathToRelative(Files.list(filePath));
         } catch (IOException e) {
             throw GorResourceException.fromIOException(e, getPath()).retry();

--- a/model/src/main/java/org/gorpipe/gor/model/GorOptions.java
+++ b/model/src/main/java/org/gorpipe/gor/model/GorOptions.java
@@ -27,6 +27,7 @@ import gorsat.Commands.CommandParseUtilities;
 import gorsat.Commands.GenomicRange;
 import gorsat.DynIterator;
 import gorsat.gorsatGorIterator.MapAndListUtilities;
+import org.gorpipe.base.concurrency.CommonThreadPools;
 import org.gorpipe.exceptions.*;
 import org.gorpipe.gor.driver.DataSource;
 import org.gorpipe.gor.driver.filters.InFilter;
@@ -88,18 +89,7 @@ public class GorOptions {
     private final boolean useDictionaryCache = Boolean.parseBoolean(System.getProperty("gor.dictionary.cache.active", "true"));
     private final boolean useTable = false;
 
-    // See: java/util/concurrent/ForkJoinPool.java
-    private static final ForkJoinPool seekThreadPool = new ForkJoinPool(
-            16,  // Defaults to number of processors.
-            ForkJoinPool.defaultForkJoinWorkerThreadFactory,  // Same as default.
-            null,  // Same as default.
-            false,  // Same as default.
-            16,  // Defaults to the same as parallelism.
-            256,  // Same as default.
-            1,  // Same as default.
-            p -> true,  // Set to true, so we don't throw error if pool exhausted, instead we wait.
-            60,        // Same as default
-            TimeUnit.SECONDS);      // Same as default
+
 
 
 
@@ -449,7 +439,7 @@ public class GorOptions {
 
         List<GenomicIterator> genomicIterators;
         try {
-            genomicIterators = seekThreadPool.submit(
+            genomicIterators = CommonThreadPools.seekThreadPool.submit(
                     () -> preparedSources.parallel().map(this::createGenomicIteratorFromRef).collect(Collectors.toList())).get();
         } catch (Exception e) {
             throw ExceptionUtilities.wrapExceptionInGorSystemException(e);


### PR DESCRIPTION
Fixed by using custom thread pool for Merger Iterator.