### PR TITLE
fix(ENGKNOW-3766): guard empty tabix contig set in VcfGzTabixGenomicIterator

### DIFF
--- a/model/src/main/java/org/gorpipe/gor/model/VcfGzTabixGenomicIterator.java
+++ b/model/src/main/java/org/gorpipe/gor/model/VcfGzTabixGenomicIterator.java
@@ -143,56 +143,40 @@ public class VcfGzTabixGenomicIterator extends GenomicIteratorBase {
 
     @Override
     public boolean hasNext() {
-        if (nextRow != null) {
-            return true;
-        }
-        if (iterator == null) {
-            var chr = hgSeekIndex.next();
-            var seekChr = chrs.get(chr);
-            iterator = reader.query(seekChr, 0, Integer.MAX_VALUE);
-        }
-        if (iterator != null) {
+        // The chromosomes come from the tabix index, which is empty for a header only vcf file, so
+        // hgSeekIndex must always be guarded before advancing it.
+        while (nextRow == null) {
+            if (iterator == null) {
+                if (!hgSeekIndex.hasNext()) {
+                    return false;
+                }
+                iterator = reader.query(chrs.get(hgSeekIndex.next()), 0, Integer.MAX_VALUE);
+                if (iterator == null) {
+                    continue;
+                }
+            }
             try {
                 String s = iterator.next();
                 if (s == null) {
                     iterator = null;
-                    if(hgSeekIndex.hasNext()) {
-                        return hasNext();
-                    } else {
-                        return false;
-                    }
                 } else {
                     nextRow = createRow(s);
-                    return true;
                 }
             } catch (IOException e) {
                 throw new GorResourceException("Error reading file", fileName, e);
             }
         }
-        return false;
+        return true;
     }
 
     @Override
     public Row next() {
-        if (nextRow != null) {
-            Row row = nextRow;
-            nextRow = null;
-            return row;
+        if (!hasNext()) {
+            return null;
         }
-        if (iterator == null) {
-            iterator = reader.query(chrs.get(hgSeekIndex.next()), 0, Integer.MAX_VALUE);
-        }
-
-        if (iterator != null) {
-            try {
-                final String s = iterator.next();
-                return createRow(s);
-            } catch (IOException e) {
-                throw new GorResourceException("Error reading file", fileName, e);
-            }
-        }
-
-        return null;
+        Row row = nextRow;
+        nextRow = null;
+        return row;
     }
 
     @Override

--- a/model/src/test/java/org/gorpipe/gor/model/UTestVcfTabixGenomicIterator.java
+++ b/model/src/test/java/org/gorpipe/gor/model/UTestVcfTabixGenomicIterator.java
@@ -23,6 +23,7 @@
 package org.gorpipe.gor.model;
 
 import gorsat.TestUtils;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.tribble.index.IndexFactory;
 import htsjdk.tribble.index.tabix.TabixIndex;
 import htsjdk.variant.vcf.VCFCodec;
@@ -32,10 +33,13 @@ import org.gorpipe.gor.util.DataUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -46,10 +50,16 @@ public class UTestVcfTabixGenomicIterator {
     FileSource fs;
     FileSource fi;
     ChromoLookup cl;
+
+    @Rule
+    public TemporaryFolder workDir = new TemporaryFolder();
+    private Path workDirPath;
+
     String ipath = DataUtil.toFile(DataUtil.toFile( "../tests/data/external/samtools/testTabixIndex", DataType.VCFGZ), DataType.TBI);
 
     @Before
     public void init() throws IOException {
+        workDirPath = workDir.getRoot().toPath();
         tabixIndexPath = Paths.get(ipath);
         cl = new DefaultChromoLookup();
         String path = DataUtil.toFile( "../tests/data/external/samtools/testTabixIndex", DataType.VCFGZ);
@@ -103,6 +113,61 @@ public class UTestVcfTabixGenomicIterator {
         try (VcfGzTabixGenomicIterator vcfit = new VcfGzTabixGenomicIterator(cl, fs, fi)) {
             Assert.assertTrue("Tabix indexed vcf file seek failed", vcfit.seek("chr1", 327));
         }
+    }
+
+    /**
+     * A header-only bgzipped vcf produces a valid tabix index with an empty sequence dictionary,
+     * see ENGKNOW-3766.
+     */
+    private Path createHeaderOnlyVcf() throws IOException {
+        Path vcfPath = workDirPath.resolve(DataUtil.toFile("empty", DataType.VCFGZ));
+        try (BlockCompressedOutputStream os = new BlockCompressedOutputStream(vcfPath.toFile())) {
+            os.write(("##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n")
+                    .getBytes(StandardCharsets.UTF_8));
+        }
+        TabixIndex index = IndexFactory.createTabixIndex(vcfPath.toFile(), new VCFCodec(), null);
+        index.write(Paths.get(DataUtil.toFile(vcfPath.toString(), DataType.TBI)));
+        return vcfPath;
+    }
+
+    @Test
+    public void testHeaderOnlyVcfTabixHasNextIsFalse() throws IOException {
+        Path vcfPath = createHeaderOnlyVcf();
+        try (VcfGzTabixGenomicIterator vcfit = new VcfGzTabixGenomicIterator(cl,
+                new FileSource(vcfPath.toString()),
+                new FileSource(DataUtil.toFile(vcfPath.toString(), DataType.TBI)))) {
+            Assert.assertFalse("Header only vcf file should have no rows", vcfit.hasNext());
+        }
+    }
+
+    @Test
+    public void testHeaderOnlyVcfTabixNextIsNull() throws IOException {
+        Path vcfPath = createHeaderOnlyVcf();
+        try (VcfGzTabixGenomicIterator vcfit = new VcfGzTabixGenomicIterator(cl,
+                new FileSource(vcfPath.toString()),
+                new FileSource(DataUtil.toFile(vcfPath.toString(), DataType.TBI)))) {
+            Assert.assertNull("Header only vcf file should return no row", vcfit.next());
+        }
+    }
+
+    @Test
+    public void testHeaderOnlyVcfTabixGetHeader() throws IOException {
+        Path vcfPath = createHeaderOnlyVcf();
+        try (VcfGzTabixGenomicIterator vcfit = new VcfGzTabixGenomicIterator(cl,
+                new FileSource(vcfPath.toString()),
+                new FileSource(DataUtil.toFile(vcfPath.toString(), DataType.TBI)))) {
+            Assert.assertEquals("Wrong header from header only vcf file",
+                    "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO",
+                    String.join("\t", vcfit.getHeader()));
+        }
+    }
+
+    @Test
+    public void testHeaderOnlyVcfTabixQuery() throws IOException {
+        Path vcfPath = createHeaderOnlyVcf();
+        String results = TestUtils.runGorPipe("gor " + vcfPath + " | top 5");
+        Assert.assertEquals("Header only vcf file should give an empty result",
+                "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n", results);
     }
 
     @After


### PR DESCRIPTION
## Problem

A header-only bgzipped VCF (valid header, zero data rows) produces a valid tabix index with an empty sequence dictionary. Reading one throws instead of returning zero rows:

```
org.gorpipe.exceptions.GorSystemException: class java.util.NoSuchElementException: null
  at java.util.TreeMap$KeyIterator.next(TreeMap.java:1540)
  at org.gorpipe.gor.model.VcfGzTabixGenomicIterator.hasNext(VcfGzTabixGenomicIterator.java:150)
```

`init()` builds the chromosome map purely from `reader.getChromosomes()` — the contigs listed in the `.tbi` index, never from the VCF body — then sets `hgSeekIndex = chrs.keySet().iterator()`. With an empty index that map is empty, and both `hasNext()` and `next()` called `hgSeekIndex.next()` with no guard, so the very first `hasNext()` threw before any row was read.

`seek()` was already guarded (`while (hgSeekIndex.hasNext())`), which is why `gor -p chr1 <file>` returned zero rows cleanly on the same file while an unpositioned `gor <file>` threw. That asymmetry is a quick confirmation test.

Introduced in bad1981e4 (2022-08-16), present through 36bd22a7.

### Repro

```bash
printf '##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n' | bgzip > empty.vcf.gz
tabix -p vcf empty.vcf.gz
tabix -l empty.vcf.gz          # prints nothing - zero contigs
gorpipe 'gor empty.vcf.gz | top 5'
```

Expected zero rows; got the exception above.

## Fix

- `hasNext()` guards `hgSeekIndex.hasNext()` before advancing and returns `false` once the contig set is exhausted. The tail recursion over chromosomes becomes a `while` loop while we're in there — same behavior, no stack growth on many-contig files.
- `next()` delegates to `hasNext()` and returns `null` when exhausted. This removes the second unguarded call site and also fixes a latent `createRow(null)` NPE when the current chromosome's iterator drained without a preceding `hasNext()`.

Returning `null` on exhaustion preserves the existing contract and matches the sibling `GorGzGenomicIterator`. That iterator was checked for the same pattern and has no unguarded call.

A `try`/`catch (NoSuchElementException)` was considered instead. Rejected: the guard costs one field-null-check per chromosome rollover (not per row), while catching would also swallow a `NoSuchElementException` raised for a genuine reason deeper in htsjdk, turning a real bug into a silent empty result.

## Tests

Four regression tests in `UTestVcfTabixGenomicIterator`. The header-only `.vcf.gz` and its index are built at test time with `BlockCompressedOutputStream` + `IndexFactory.createTabixIndex` into the `TemporaryFolder` rule's work dir, so no test-data submodule change is needed.

- `hasNext()` is `false`
- `next()` is `null`
- the header still parses
- `gor <file> | top 5` runs end to end and yields header-only output

Verified as a proper red/green cycle: with the production fix stashed the three behavioral tests fail with the exact stack from the report; restored, all pass. The header test passes either way, confirming header parsing was never at fault.

- `./gradlew :model:test` — 1514 pass, 17 skipped
- `./gradlew :gortools:test` for the tabix/VCF consumers (`UTestGorTabix`, `UTestGorVcfWithHtsjdk`, `UTestNor`, `UTestProcessSource`) — 73 pass, 13 skipped

## Impact

Any header-only VCF — for example a caller that legitimately emits no calls for a sample — surfaced as an opaque system exception with a null message instead of an empty result, giving no indication that the file is simply empty and sending triage toward the storage layer, which was not at fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
