### PR TITLE
fix(ENGKNOW-3722): self-heal 416 from stale object length, bound session caches

### DIFF
--- a/drivers/build.gradle
+++ b/drivers/build.gradle
@@ -66,6 +66,7 @@ project(':drivers') {
         testImplementation 'com.github.stefanbirkner:system-rules:_'
         testImplementation "com.amazonaws:aws-java-sdk-sts:_"
         testImplementation "com.amazonaws:aws-java-sdk-s3:_"
+        testImplementation Testing.mockito.core
 
         testRuntimeOnly 'org.apache.derby:derby:_'
         testRuntimeOnly 'org.apache.derby:derbytools:_'

--- a/drivers/src/main/java/org/gorpipe/oci/driver/OCIObjectStorageRetryHandler.java
+++ b/drivers/src/main/java/org/gorpipe/oci/driver/OCIObjectStorageRetryHandler.java
@@ -42,6 +42,11 @@ public class OCIObjectStorageRetryHandler extends RetryHandlerWithFixedWait {
                 throw new GorResourceException(String.format("Access Denied. Detail: %s. Original message: %s", detail, cause.getMessage()), path, e);
             } else if (bmcException.getStatusCode() == 404) {
                 throw new GorResourceException(String.format("Not Found. Detail: %s. Original message: %s", detail, cause.getMessage()), path, e);
+            } else if (bmcException.getStatusCode() == 416) {
+                // Deterministic: the range asked for does not exist in the object, so retrying the same
+                // range cannot help.  OCIObjectStorageSource self-heals the stale-cached-length case
+                // before we get here, so anything reaching this point is a genuinely unsatisfiable range.
+                throw new GorResourceException(String.format("Requested byte range not satisfiable. Detail: %s. Original message: %s", detail, cause.getMessage()), path, e);
             }
         }
     }

--- a/drivers/src/main/java/org/gorpipe/oci/driver/OCIObjectStorageSource.java
+++ b/drivers/src/main/java/org/gorpipe/oci/driver/OCIObjectStorageSource.java
@@ -121,13 +121,43 @@ public class OCIObjectStorageSource implements StreamSource {
                         .bucketName(bucket)
                         .objectName(key);
 
-        if (range != null) {
-            range = range.limitTo(getSourceMetadata().getLength());
-            if (range.isEmpty()) return new ByteArrayInputStream(new byte[0]);
-            requestBuilder.range(new Range(range.getFirst(), range.getLast()));
+        if (range == null) {
+            return openRequest(requestBuilder.build());
         }
 
-        return openRequest(requestBuilder.build());
+        var clamped = range.limitTo(getSourceMetadata().getLength());
+        if (clamped.isEmpty()) return new ByteArrayInputStream(new byte[0]);
+
+        try {
+            return openRequest(rangedRequest(requestBuilder, clamped));
+        } catch (GorResourceException e) {
+            if (!isRangeNotSatisfiable(e)) throw e;
+
+            // The length we clamped to is stale - the object was rewritten smaller by another process.
+            // Object stores have no append, so a rewrite replaces the whole object and every other
+            // reader keeps the pre-rewrite length.  Refresh the metadata and reissue the range once.
+            log.info("Range {}-{} not satisfiable for {} - refreshing stale cached object length",
+                    clamped.getFirst(), clamped.getLast(), getName());
+            invalidateMeta();
+
+            var refreshed = range.limitTo(getSourceMetadata().getLength());
+            if (refreshed.isEmpty()) return new ByteArrayInputStream(new byte[0]);
+            return openRequest(rangedRequest(requestBuilder, refreshed));
+        }
+    }
+
+    private static GetObjectRequest rangedRequest(GetObjectRequest.Builder requestBuilder, RequestRange range) {
+        return requestBuilder.range(new Range(range.getFirst(), range.getLast())).build();
+    }
+
+    /**
+     * True for HTTP 416, which the object store returns when the requested range starts at or past the
+     * end of the object.  Deterministic for a given range and object, so it is only worth reacting to
+     * by correcting our idea of the object rather than by repeating the request.
+     */
+    private static boolean isRangeNotSatisfiable(Exception e) {
+        return ExceptionUtilities.getUnderlyingCause(e) instanceof BmcException bmcException
+                && bmcException.getStatusCode() == 416;
     }
 
     private InputStream openRequest(GetObjectRequest request) {
@@ -139,7 +169,7 @@ public class OCIObjectStorageSource implements StreamSource {
             Thread.currentThread().interrupt();
             throw new GorSystemException(e);
         } catch (Exception e) {
-            throw new GorResourceException("Failed to open S3 object: " + sourceReference.getUrl(), sourceReference.getUrl(), e).retry();
+            throw new GorResourceException("Failed to open OCI object: " + sourceReference.getUrl(), sourceReference.getUrl(), e).retry();
         }
     }
 
@@ -181,7 +211,7 @@ public class OCIObjectStorageSource implements StreamSource {
 
     private StreamSourceMetadata loadMetadataFromCache(String bucket, String key) {
         try {
-            return metadataCache.get(bucket + key, () -> createMetaData(bucket, key));
+            return metadataCache.get(metaCacheKey(), () -> createMetaData(bucket, key));
         } catch (Exception  e) {
             throw new GorResourceException("Failed to load metadata from cache for " + bucket + "/" + key, getName(), e).retry();
         }
@@ -253,7 +283,16 @@ public class OCIObjectStorageSource implements StreamSource {
 
     private void invalidateMeta() {
         meta = null;
-        metadataCache.invalidate(bucket + key);
+        metadataCache.invalidate(metaCacheKey());
+    }
+
+    /**
+     * Key for the shared metadata cache.  The namespace has to be part of it -- the same bucket and
+     * object name exist independently in different namespaces -- and the separators keep a split at a
+     * different offset from producing the same key.
+     */
+    private String metaCacheKey() {
+        return namespace + "/" + bucket + "/" + key;
     }
 
     @Override

--- a/drivers/src/main/java/org/gorpipe/s3/driver/S3RetryHandler.java
+++ b/drivers/src/main/java/org/gorpipe/s3/driver/S3RetryHandler.java
@@ -38,6 +38,11 @@ public class S3RetryHandler extends RetryHandlerWithFixedWait {
                 throw new GorResourceException(String.format("Access Denied. Detail: %s. Original message: %s", detail, e.getMessage()), path, e);
             } else if (awsException.statusCode() == 404) {
                 throw new GorResourceException(String.format("Not Found. Detail: %s. Original message: %s", detail, e.getMessage()), path, e);
+            } else if (awsException.statusCode() == 416) {
+                // Deterministic: the range asked for does not exist in the object, so retrying the same
+                // range cannot help.  S3Source self-heals the stale-cached-length case before we get
+                // here, so anything reaching this point is a genuinely unsatisfiable range.
+                throw new GorResourceException(String.format("Requested byte range not satisfiable. Detail: %s. Original message: %s", detail, e.getMessage()), path, e);
             }
         } else if (cause instanceof SdkClientException) {
             throw new GorResourceException("Amazon SDK client exception", path, e);

--- a/drivers/src/main/java/org/gorpipe/s3/driver/S3Source.java
+++ b/drivers/src/main/java/org/gorpipe/s3/driver/S3Source.java
@@ -173,12 +173,44 @@ public class S3Source implements StreamSource {
 
     private InputStream open(RequestRange range) {
         var reqBuilder = GetObjectRequest.builder().bucket(bucket).key(key);
-        if (range!=null) {
-            range = range.limitTo(getSourceMetadata().getLength());
-            if (range.isEmpty()) return new ByteArrayInputStream(new byte[0]);
-            reqBuilder.range(BytesRange.startLengthtoRange(range.getFirst(), range.getLength()));
+        if (range == null) {
+            return openRequest(reqBuilder.build());
         }
-        return openRequest(reqBuilder.build());
+
+        var clamped = range.limitTo(getSourceMetadata().getLength());
+        if (clamped.isEmpty()) return new ByteArrayInputStream(new byte[0]);
+
+        try {
+            return openRequest(rangedRequest(reqBuilder, clamped));
+        } catch (GorResourceException e) {
+            if (!isRangeNotSatisfiable(e)) throw e;
+
+            // The length we clamped to is stale.  S3 has no append, so both LinkFile.save and
+            // versioned link GC replace the whole object, and a writer in another process shrinking
+            // the object leaves our cached length pointing past the new end.  Refresh the metadata
+            // and reissue the range once against the current length.
+            log.info("Range {} not satisfiable for {} - refreshing stale cached object length",
+                    BytesRange.startLengthtoRange(clamped.getFirst(), clamped.getLength()), getFullS3Url());
+            invalidateMeta();
+
+            var refreshed = range.limitTo(getSourceMetadata().getLength());
+            if (refreshed.isEmpty()) return new ByteArrayInputStream(new byte[0]);
+            return openRequest(rangedRequest(reqBuilder, refreshed));
+        }
+    }
+
+    private static GetObjectRequest rangedRequest(GetObjectRequest.Builder reqBuilder, RequestRange range) {
+        return reqBuilder.range(BytesRange.startLengthtoRange(range.getFirst(), range.getLength())).build();
+    }
+
+    /**
+     * True for HTTP 416, which S3 returns when the requested range starts at or past the end of the
+     * object.  Deterministic for a given range and object, so it is only worth reacting to by
+     * correcting our idea of the object rather than by repeating the request.
+     */
+    private static boolean isRangeNotSatisfiable(Exception e) {
+        return ExceptionUtilities.getUnderlyingCause(e) instanceof S3Exception s3Exception
+                && s3Exception.statusCode() == 416;
     }
 
     private InputStream openWithFileSystem(RequestRange range) {
@@ -247,7 +279,7 @@ public class S3Source implements StreamSource {
     private S3SourceMetadata loadMetadataFromCache(String bucket, String key) {
         try {
             // We can not use the cache if the session is not available, as the cache needs to be cleared when the session ends.
-            return (S3SourceMetadata)metadataCache.get(bucket + key, k -> {
+            return (S3SourceMetadata)metadataCache.get(metaCacheKey(), k -> {
                 // TODO:  If the object does not exists we don't cache.  This method will throw exception and the loader will exit.
                 return createMetaData(bucket, key);
             });
@@ -414,7 +446,16 @@ public class S3Source implements StreamSource {
 
     private void invalidateMeta() {
         meta = null;
-        if (metadataCache != null) metadataCache.invalidate(bucket + key);
+        if (metadataCache != null) metadataCache.invalidate(metaCacheKey());
+    }
+
+    /**
+     * Key for the shared metadata cache.  The separator matters: without it bucket {@code ab} + key
+     * {@code c} and bucket {@code a} + key {@code bc} collide on {@code abc}, so two unrelated objects
+     * would share a cached length and invalidating one would clear the other.
+     */
+    private String metaCacheKey() {
+        return bucket + "/" + key;
     }
 
     public String copy(S3Source dest) throws IOException {

--- a/drivers/src/test/java/org/gorpipe/oci/driver/UTestOCIObjectStorageRetryHandler.java
+++ b/drivers/src/test/java/org/gorpipe/oci/driver/UTestOCIObjectStorageRetryHandler.java
@@ -1,0 +1,57 @@
+package org.gorpipe.oci.driver;
+
+import com.oracle.bmc.model.BmcException;
+import org.gorpipe.exceptions.GorResourceException;
+import org.gorpipe.gor.driver.utils.RetryHandlerBase;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for how {@link OCIObjectStorageRetryHandler} classifies object store status codes.
+ *
+ * <p>The S3 counterpart of this, {@link org.gorpipe.s3.driver.UTestS3RetryHandler}, covers the same
+ * ground for ENGKNOW-3722: a stale cached object length produces a deterministic
+ * {@code 416 Range Not Satisfiable}, which must not be run through the retry ladder.
+ */
+public class UTestOCIObjectStorageRetryHandler {
+
+    private static GorResourceException ociFailure(int statusCode, String detail) {
+        return (GorResourceException) new GorResourceException(
+                "Failed to open OCI object: oci://bucket/some/file.gor.link",
+                "oci://bucket/some/file.gor.link",
+                new BmcException(statusCode, "TestServiceCode", detail, "test-opc-request-id")).retry();
+    }
+
+    @Test
+    public void rangeNotSatisfiableFailsWithoutRetrying() {
+        var handler = new OCIObjectStorageRetryHandler(100, 1000);
+        var attempts = new AtomicInteger();
+
+        assertThrows(GorResourceException.class, () ->
+                handler.perform((RetryHandlerBase.ActionVoid) () -> {
+                    attempts.incrementAndGet();
+                    throw ociFailure(416, "The requested range is not satisfiable");
+                }));
+
+        assertEquals("a 416 is deterministic and must fail on the first attempt", 1, attempts.get());
+    }
+
+    @Test
+    public void serverErrorIsStillRetried() {
+        var handler = new OCIObjectStorageRetryHandler(100, 1000);
+        var attempts = new AtomicInteger();
+
+        assertThrows(Exception.class, () ->
+                handler.perform((RetryHandlerBase.ActionVoid) () -> {
+                    attempts.incrementAndGet();
+                    throw ociFailure(500, "Internal Server Error");
+                }));
+
+        assertTrue("transient server errors must keep retrying", attempts.get() > 1);
+    }
+}

--- a/drivers/src/test/java/org/gorpipe/oci/driver/UTestOCIObjectStorageSourceStaleMetadata.java
+++ b/drivers/src/test/java/org/gorpipe/oci/driver/UTestOCIObjectStorageSourceStaleMetadata.java
@@ -1,0 +1,118 @@
+package org.gorpipe.oci.driver;
+
+import com.oracle.bmc.model.BmcException;
+import com.oracle.bmc.objectstorage.ObjectStorageAsync;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import com.oracle.bmc.objectstorage.requests.HeadObjectRequest;
+import com.oracle.bmc.objectstorage.responses.HeadObjectResponse;
+import org.gorpipe.exceptions.GorResourceException;
+import org.gorpipe.gor.driver.meta.SourceReference;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The stale-object-length cases from ENGKNOW-3722, for the native OCI driver.
+ *
+ * <p>{@link OCIObjectStorageSource} clamps every ranged GET to a cached object length exactly as the
+ * S3 driver does, so an object rewritten smaller by another process produces the same deterministic
+ * {@code 416}. Its cache has a 5 minute expiry, which narrows the window but does not close it.
+ *
+ * <p>The cache key is also missing the namespace, so two objects with the same bucket and key in
+ * different namespaces share one cached length.
+ */
+public class UTestOCIObjectStorageSourceStaleMetadata {
+
+    private static final long STALE_LENGTH = 98825;
+    private static final long ACTUAL_LENGTH = 98674;
+    private static final long REOPEN_LENGTH = 262144;
+
+    private static HeadObjectResponse head(long contentLength) {
+        return HeadObjectResponse.builder()
+                .contentLength(contentLength)
+                .lastModified(new Date())
+                .build();
+    }
+
+    private static BmcException bmcError(int statusCode, String message) {
+        return new BmcException(statusCode, "TestServiceCode", message, "test-opc-request-id");
+    }
+
+    private static String nativeUrl(String namespace, String bucket, String path) {
+        return String.format("https://%s.objectstorage.us-ashburn-1.oci.customer-oci.com/n/%s/b/%s/o/%s",
+                namespace, namespace, bucket, path);
+    }
+
+    private static OCIObjectStorageSource sourceFor(ObjectStorageAsync client, String namespace,
+                                                    String bucket, String path) {
+        try {
+            return new OCIObjectStorageSource(client, new SourceReference(nativeUrl(namespace, bucket, path)));
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Test
+    public void rangePastEndOfShrunkObjectReadsAsEndOfFile() throws Exception {
+        ObjectStorageAsync client = mock(ObjectStorageAsync.class);
+        when(client.headObject(any(HeadObjectRequest.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(head(STALE_LENGTH)),
+                        CompletableFuture.completedFuture(head(ACTUAL_LENGTH)));
+        when(client.getObject(any(GetObjectRequest.class), any()))
+                .thenReturn(CompletableFuture.failedFuture(
+                        bmcError(416, "The requested range is not satisfiable")));
+
+        var source = sourceFor(client, "ns" + UUID.randomUUID(), "thebucket", "ref/" + UUID.randomUUID() + "/gmb_disease_map.tsv.link");
+
+        try (InputStream is = source.open(ACTUAL_LENGTH, REOPEN_LENGTH)) {
+            assertEquals("a range wholly past the end of the rewritten object is end-of-file",
+                    -1, is.read());
+        }
+
+        verify(client, times(2)).headObject(any(HeadObjectRequest.class), any());
+    }
+
+    @Test
+    public void otherErrorsDoNotRefreshMetadata() throws Exception {
+        ObjectStorageAsync client = mock(ObjectStorageAsync.class);
+        when(client.headObject(any(HeadObjectRequest.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(head(STALE_LENGTH)));
+        when(client.getObject(any(GetObjectRequest.class), any()))
+                .thenReturn(CompletableFuture.failedFuture(bmcError(403, "Access Denied")));
+
+        var source = sourceFor(client, "ns" + UUID.randomUUID(), "thebucket", "ref/" + UUID.randomUUID() + "/gmb_disease_map.tsv.link");
+
+        assertThrows(GorResourceException.class, () -> source.open(0, 100));
+
+        verify(client, times(1)).headObject(any(HeadObjectRequest.class), any());
+    }
+
+    @Test
+    public void metadataCacheKeysIncludeTheNamespace() throws Exception {
+        var id = UUID.randomUUID().toString().replace("-", "");
+        ObjectStorageAsync client = mock(ObjectStorageAsync.class);
+        when(client.headObject(any(HeadObjectRequest.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(head(100)),
+                        CompletableFuture.completedFuture(head(200)));
+
+        var first = sourceFor(client, "nsone" + id, "thebucket", "shared/file.link");
+        var second = sourceFor(client, "nstwo" + id, "thebucket", "shared/file.link");
+
+        assertEquals(100L, first.getSourceMetadata().getLength().longValue());
+        assertEquals("an object in another namespace must get its own length",
+                200L, second.getSourceMetadata().getLength().longValue());
+
+        verify(client, times(2)).headObject(any(HeadObjectRequest.class), any());
+    }
+}

--- a/drivers/src/test/java/org/gorpipe/s3/driver/ITestS3LinkFileRewrite.java
+++ b/drivers/src/test/java/org/gorpipe/s3/driver/ITestS3LinkFileRewrite.java
@@ -1,0 +1,137 @@
+package org.gorpipe.s3.driver;
+
+import org.gorpipe.gor.driver.linkfile.LinkFile;
+import org.gorpipe.gor.driver.meta.SourceReference;
+import org.gorpipe.gor.driver.providers.stream.sources.StreamSource;
+import org.gorpipe.gor.driver.providers.stream.sources.wrappers.ExtendedRangeWrapper;
+import org.gorpipe.gor.driver.providers.stream.sources.wrappers.RetryStreamSourceWrapper;
+import org.gorpipe.test.IntegrationTests;
+import org.gorpipe.utils.DriverUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * End-to-end regression test for ENGKNOW-3722, against real S3.
+ *
+ * <p>Reads a versioned {@code .link} file through the production wrapper chain
+ * ({@code ExtendedRangeWrapper} over {@code RetryStreamSourceWrapper} over {@link S3Source}), then has
+ * a second writer replace the object with a much smaller one, then reads it again in the same JVM.
+ *
+ * <p>The rewrite goes through the raw {@link S3Client} on purpose. {@code S3Source.getOutputStream}
+ * calls {@code invalidateMeta()}, which would clear this JVM's cached length and hide the bug; in
+ * production the writer is a different pod, so every other reader keeps the pre-rewrite length. Those
+ * readers then clamp their next range to the old, larger length, request bytes at or past the new end
+ * of the object, and get {@code 416 Range Not Satisfiable}.
+ *
+ * <p>Before the fix the second read fails with
+ * {@code byte range bytes=<n>-<m> cannot be satisfied from object with content length <n>}.
+ */
+@Category(IntegrationTests.class)
+public class ITestS3LinkFileRewrite {
+
+    private static final String BUCKET = "gdb-unit-test-data";
+    private static final String REGION = "eu-west-1";
+    private static final String KEY_PREFIX = "csa_test_data/data_sets/gor_driver_testfiles/engknow3722/";
+
+    private static String s3Key;
+    private static String s3Secret;
+
+    @BeforeClass
+    public static void setUpClass() {
+        var props = DriverUtils.getDriverProperties();
+        s3Key = props.getProperty("S3_KEY");
+        s3Secret = props.getProperty("S3_SECRET");
+    }
+
+    private static S3Client newClient() {
+        return S3Client.builder()
+                .region(Region.of(REGION))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.builder().accessKeyId(s3Key).secretAccessKey(s3Secret).build()))
+                .build();
+    }
+
+    /** A many-versioned link file, the shape that versioned-link GC later compacts. */
+    private static String manyVersionsLinkBody(int entries) {
+        var sb = new StringBuilder();
+        sb.append("## SERIAL = ").append(entries).append('\n');
+        sb.append("## VERSION = 1\n");
+        sb.append("#FILE\tTIMESTAMP\tMD5\tSERIAL\tINFO\n");
+        var base = Instant.parse("2026-01-01T00:00:00.000Z");
+        for (int i = 1; i <= entries; i++) {
+            sb.append("source/versions/generation_").append(i).append(".gorz\t")
+                    .append(base.plusSeconds(i)).append("\tMD5SUM").append(i).append("\t")
+                    .append(i).append("\t\n");
+        }
+        return sb.toString();
+    }
+
+    /** What the link file looks like after compaction: a single surviving entry. */
+    private static String compactedLinkBody() {
+        return """
+                ## SERIAL = 1
+                ## VERSION = 1
+                #FILE\tTIMESTAMP\tMD5\tSERIAL\tINFO
+                source/versions/compacted.gorz\t2026-02-01T00:00:00.000Z\tMD5SUMC\t1\t
+                """;
+    }
+
+    private static void put(S3Client client, String key, String body) {
+        client.putObject(PutObjectRequest.builder().bucket(BUCKET).key(key).build(),
+                RequestBody.fromString(body));
+    }
+
+    /** Reads the link file through the same wrapper chain {@code StreamSourceProvider.wrap} builds. */
+    private static String latestEntryUrl(S3Client client, String url) throws Exception {
+        // Short retry budget: this test is about whether the read succeeds, not about how long the
+        // retry ladder takes. UTestS3RetryHandler covers the fail-fast classification.
+        StreamSource wrapped = new ExtendedRangeWrapper(
+                new RetryStreamSourceWrapper(new S3RetryHandler(100, 2000),
+                        new S3Source(client, new SourceReference(url))),
+                65536, 8 * 1024 * 1024);
+        try (wrapped) {
+            return LinkFile.load(wrapped).getLatestEntryUrl();
+        }
+    }
+
+    @Test
+    public void linkFileCompactedByAnotherWriterIsStillReadable() throws Exception {
+        var key = KEY_PREFIX + UUID.randomUUID() + "/dbsnp_test.gorz.link";
+        var url = "s3://" + BUCKET + "/" + key;
+
+        try (var client = newClient()) {
+            var large = manyVersionsLinkBody(1200);
+            put(client, key, large);
+
+            // First read: seeds this JVM's S3 metadata cache with the pre-compaction length.
+            assertTrue("first read must resolve the newest generation",
+                    latestEntryUrl(client, url).endsWith("generation_1200.gorz"));
+
+            // Another writer compacts the link file. Much smaller object, same key, and this JVM's
+            // cached length is not invalidated.
+            put(client, key, compactedLinkBody());
+            assertTrue("the compacted link file must be smaller than the original",
+                    compactedLinkBody().length() < large.length());
+
+            assertTrue("a link file rewritten smaller must still be readable",
+                    latestEntryUrl(client, url).endsWith("compacted.gorz"));
+        } finally {
+            try (var client = newClient()) {
+                client.deleteObject(DeleteObjectRequest.builder().bucket(BUCKET).key(key).build());
+            }
+        }
+    }
+}

--- a/drivers/src/test/java/org/gorpipe/s3/driver/ITestS3LinkFileRewrite.java
+++ b/drivers/src/test/java/org/gorpipe/s3/driver/ITestS3LinkFileRewrite.java
@@ -126,8 +126,9 @@ public class ITestS3LinkFileRewrite {
             assertTrue("the compacted link file must be smaller than the original",
                     compactedLinkBody().length() < large.length());
 
-            assertTrue("a link file rewritten smaller must still be readable",
-                    latestEntryUrl(client, url).endsWith("compacted.gorz"));
+            var afterCompaction = latestEntryUrl(client, url);
+            assertTrue("a link file rewritten smaller must still be readable, got: " + afterCompaction,
+                    afterCompaction.endsWith("compacted.gorz"));
         } finally {
             try (var client = newClient()) {
                 client.deleteObject(DeleteObjectRequest.builder().bucket(BUCKET).key(key).build());

--- a/drivers/src/test/java/org/gorpipe/s3/driver/UTestS3RetryHandler.java
+++ b/drivers/src/test/java/org/gorpipe/s3/driver/UTestS3RetryHandler.java
@@ -1,0 +1,59 @@
+package org.gorpipe.s3.driver;
+
+import org.gorpipe.exceptions.GorResourceException;
+import org.gorpipe.gor.driver.utils.RetryHandlerBase;
+import org.junit.Test;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for how {@link S3RetryHandler} classifies S3 status codes as retryable or not.
+ *
+ * <p>Regression coverage for ENGKNOW-3722: a stale cached object length makes GOR request a byte
+ * range beyond the object's end, which S3 answers with a deterministic
+ * {@code 416 Range Not Satisfiable}. That status was missing from the handler's non-retryable list,
+ * so every occurrence burned the full retry ladder (~167 s in production) before failing anyway.
+ */
+public class UTestS3RetryHandler {
+
+    private static GorResourceException s3Failure(int statusCode, String detail) {
+        return (GorResourceException) new GorResourceException(
+                "Failed to open S3 object: s3://bucket/some/file.gor.link",
+                "s3://bucket/some/file.gor.link",
+                S3Exception.builder().statusCode(statusCode).message(detail).build()).retry();
+    }
+
+    @Test
+    public void rangeNotSatisfiableFailsWithoutRetrying() {
+        var handler = new S3RetryHandler(100, 1000);
+        var attempts = new AtomicInteger();
+
+        assertThrows(GorResourceException.class, () ->
+                handler.perform((RetryHandlerBase.ActionVoid) () -> {
+                    attempts.incrementAndGet();
+                    throw s3Failure(416, "byte range bytes=98674-98824 cannot be satisfied "
+                            + "from object with content length 98674");
+                }));
+
+        assertEquals("a 416 is deterministic and must fail on the first attempt", 1, attempts.get());
+    }
+
+    @Test
+    public void serverErrorIsStillRetried() {
+        var handler = new S3RetryHandler(100, 1000);
+        var attempts = new AtomicInteger();
+
+        assertThrows(Exception.class, () ->
+                handler.perform((RetryHandlerBase.ActionVoid) () -> {
+                    attempts.incrementAndGet();
+                    throw s3Failure(500, "Internal Error");
+                }));
+
+        assertTrue("transient server errors must keep retrying", attempts.get() > 1);
+    }
+}

--- a/drivers/src/test/java/org/gorpipe/s3/driver/UTestS3SourceStaleMetadata.java
+++ b/drivers/src/test/java/org/gorpipe/s3/driver/UTestS3SourceStaleMetadata.java
@@ -1,0 +1,166 @@
+package org.gorpipe.s3.driver;
+
+import org.gorpipe.exceptions.GorResourceException;
+import org.gorpipe.gor.driver.meta.SourceReference;
+import org.junit.Test;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests how {@link S3Source} recovers when the object length it cached no longer matches the object.
+ *
+ * <p>Regression coverage for ENGKNOW-3722. {@code S3Source.open(RequestRange)} clamps every ranged
+ * GET to {@code getSourceMetadata().getLength()}, which is served from a cache. A {@code .link} file
+ * rewritten smaller by another pod (S3 has no append, so {@code LinkFile.save} and versioned-link GC
+ * both replace the whole object) leaves readers holding the old, larger length. They then ask for a
+ * range starting at or past the new end and S3 answers {@code 416 Range Not Satisfiable} — in
+ * production, 220 failed queries in 14 days, each after ~167 s of pointless retries.
+ *
+ * <p>The lengths below are the real signature from the production logs: a link file that shrank from
+ * 98825 to 98674 bytes.
+ */
+public class UTestS3SourceStaleMetadata {
+
+    private static final long STALE_LENGTH = 98825;
+    private static final long ACTUAL_LENGTH = 98674;
+
+    /**
+     * What {@code ExtendedRangeStream} actually asks for once {@code StreamUtils.readString} requests
+     * 200000 bytes: it drains the first 128 kb request, then reopens at the position it reached with
+     * double the length. {@link S3Source} clamps that to the cached length, which is how the
+     * production range {@code bytes=98674-98824} arises.
+     */
+    private static final long REOPEN_LENGTH = 262144;
+
+    private static HeadObjectResponse head(long contentLength) {
+        return HeadObjectResponse.builder()
+                .contentLength(contentLength)
+                .lastModified(Instant.now())
+                .build();
+    }
+
+    private static S3Exception rangeNotSatisfiable() {
+        return (S3Exception) S3Exception.builder()
+                .statusCode(416)
+                .message(String.format("byte range bytes=%d-%d cannot be satisfied from object with "
+                        + "content length %d", ACTUAL_LENGTH, STALE_LENGTH - 1, ACTUAL_LENGTH))
+                .build();
+    }
+
+    private static ResponseInputStream<GetObjectResponse> body(byte[] content) {
+        return new ResponseInputStream<>(
+                GetObjectResponse.builder().contentLength((long) content.length).build(),
+                new ByteArrayInputStream(content));
+    }
+
+    /** A distinct key per test, so the process-wide static metadata cache cannot leak between them. */
+    private static S3Source sourceFor(S3Client client) {
+        var url = "s3://thebucket/ref/" + UUID.randomUUID() + "/gmb_disease_map.tsv.link";
+        try {
+            return new S3Source(client, new SourceReference(url));
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Test
+    public void rangePastEndOfShrunkObjectReadsAsEndOfFile() throws Exception {
+        S3Client client = mock(S3Client.class);
+        when(client.headObject(any(HeadObjectRequest.class)))
+                .thenReturn(head(STALE_LENGTH), head(ACTUAL_LENGTH));
+        when(client.getObject(any(GetObjectRequest.class)))
+                .thenThrow(rangeNotSatisfiable());
+
+        var source = sourceFor(client);
+
+        try (InputStream is = source.open(ACTUAL_LENGTH, REOPEN_LENGTH)) {
+            assertEquals("a range wholly past the end of the rewritten object is end-of-file",
+                    -1, is.read());
+        }
+
+        verify(client, times(2)).headObject(any(HeadObjectRequest.class));
+        verify(client, times(1)).getObject(any(GetObjectRequest.class));
+    }
+
+    @Test
+    public void rangeIsReissuedWhenRefreshedLengthStillCoversIt() throws Exception {
+        long grownLength = 200000;
+        byte[] expected = new byte[(int) (STALE_LENGTH - ACTUAL_LENGTH)];
+        java.util.Arrays.fill(expected, (byte) 'x');
+
+        S3Client client = mock(S3Client.class);
+        when(client.headObject(any(HeadObjectRequest.class)))
+                .thenReturn(head(STALE_LENGTH), head(grownLength));
+        when(client.getObject(any(GetObjectRequest.class)))
+                .thenThrow(rangeNotSatisfiable())
+                .thenReturn(body(expected));
+
+        var source = sourceFor(client);
+
+        try (InputStream is = source.open(ACTUAL_LENGTH, REOPEN_LENGTH)) {
+            assertEquals("the refreshed range must be fetched, not reported as end-of-file",
+                    expected.length, is.readAllBytes().length);
+        }
+
+        verify(client, times(2)).getObject(any(GetObjectRequest.class));
+    }
+
+    /**
+     * The metadata cache key was {@code bucket + key} with no separator, so a bucket/key split at a
+     * different offset produced the same key: bucket {@code ab<id>} + key {@code c/file.link} and
+     * bucket {@code a} + key {@code b<id>c/file.link} both concatenate to {@code ab<id>c/file.link}.
+     * Two unrelated objects would then share a cached length -- and an invalidation of one would clear
+     * the other.
+     */
+    @Test
+    public void metadataCacheKeysDoNotCollideAcrossTheBucketBoundary() throws Exception {
+        var id = UUID.randomUUID().toString().replace("-", "");
+        S3Client client = mock(S3Client.class);
+        when(client.headObject(any(HeadObjectRequest.class)))
+                .thenReturn(head(100), head(200));
+
+        var first = new S3Source(client, new SourceReference("s3://ab" + id + "/c/file.link"));
+        var second = new S3Source(client, new SourceReference("s3://a/b" + id + "c/file.link"));
+
+        assertEquals(100L, first.getSourceMetadata().getLength().longValue());
+        assertEquals("the second object must get its own length, not the first object's",
+                200L, second.getSourceMetadata().getLength().longValue());
+
+        verify(client, times(2)).headObject(any(HeadObjectRequest.class));
+    }
+
+    @Test
+    public void otherS3ErrorsDoNotRefreshMetadata() throws Exception {
+        S3Client client = mock(S3Client.class);
+        when(client.headObject(any(HeadObjectRequest.class)))
+                .thenReturn(head(STALE_LENGTH));
+        when(client.getObject(any(GetObjectRequest.class)))
+                .thenThrow((S3Exception) S3Exception.builder()
+                        .statusCode(403).message("Access Denied").build());
+
+        var source = sourceFor(client);
+
+        assertThrows(GorResourceException.class, () -> source.open(0, 100));
+
+        verify(client, times(1)).headObject(any(HeadObjectRequest.class));
+        verify(client, times(1)).getObject(any(GetObjectRequest.class));
+    }
+}

--- a/model/src/main/java/org/gorpipe/gor/session/GorSessionCache.java
+++ b/model/src/main/java/org/gorpipe/gor/session/GorSessionCache.java
@@ -48,8 +48,20 @@ public class GorSessionCache {
     private final Map<String, Object> objectHashMap = new ConcurrentHashMap<>();
     private final Map<String, Integer> fileSegMap = new ConcurrentHashMap<>();
     private final Map<String, Set<String>> sets = new HashMap<>();  // Synchronized on access
-    private final Cache<String, Object> s3MetadataCache = Caffeine.newBuilder().build();
-    private static final Cache<StreamSource, String> linkCache = Caffeine.newBuilder().maximumSize(10000).build();
+    // Bounded on purpose (ENGKNOW-3722): gor-worker sessions are long-lived, and an unbounded, never
+    // expiring cache could serve an object length for the lifetime of the process.  A .link file
+    // rewritten by another pod then leaves this session clamping ranges to a length that no longer
+    // exists.  Matches the expiry of the static fallback cache in S3Source.
+    private final Cache<String, Object> s3MetadataCache = Caffeine.newBuilder()
+            .maximumSize(10000)
+            .expireAfterWrite(5, TimeUnit.MINUTES).build();
+    // Per session and expiring (ENGKNOW-3722): as a static cache this held link content for the whole
+    // process, so content read by one session was served to every later one.  Link files get rewritten,
+    // so content held past its session may no longer be true.  Matches the bounds of the static
+    // fallback cache in LinkFile.
+    private final Cache<StreamSource, String> linkCache = Caffeine.newBuilder()
+            .maximumSize(10000)
+            .expireAfterWrite(5, TimeUnit.MINUTES).build();
 
 
     public Map<String, Long> getSeekTimes() {

--- a/model/src/test/java/org/gorpipe/gor/session/UTestGorSessionCache.java
+++ b/model/src/test/java/org/gorpipe/gor/session/UTestGorSessionCache.java
@@ -1,0 +1,89 @@
+package org.gorpipe.gor.session;
+
+import org.gorpipe.gor.driver.providers.stream.sources.StreamSource;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for the caches held by a {@link GorSessionCache}.
+ *
+ * <p>Regression coverage for ENGKNOW-3722. The session S3 metadata cache had neither an expiry nor
+ * a size bound, and {@code gor.s3.meta.cache.session=true} is the default, so a long-lived
+ * gor-worker session could hold an object length for the lifetime of the process. When another pod
+ * rewrote a {@code .link} file smaller, readers kept clamping ranges to the old, larger length:
+ * a range past the new end returns {@code 416}, and a range short of a new, larger end silently
+ * truncates the link content. Bounding the staleness window bounds both failures.
+ */
+public class UTestGorSessionCache {
+
+    @Test
+    public void s3MetadataCacheEntriesExpire() {
+        var cache = new GorSessionCache().getS3MetadataCache();
+
+        var expiry = cache.policy().expireAfterWrite().orElseThrow(() -> new AssertionError(
+                "session S3 metadata cache has no write expiry, so a stale object length can be "
+                        + "cached for the whole lifetime of a long-running session"));
+
+        assertTrue("staleness window must be at most 5 minutes, matching the static metadata cache",
+                expiry.getExpiresAfter(TimeUnit.MINUTES) <= 5);
+
+        expiry.setExpiresAfter(Duration.ofNanos(1));
+        cache.put("thebucket/some/file.gor.link", "stale-metadata");
+        cache.cleanUp();
+
+        assertNull("an expired object length must not be served again",
+                cache.getIfPresent("thebucket/some/file.gor.link"));
+    }
+
+    /**
+     * The link cache was {@code static}, so cached link content outlived the session that read it and
+     * was visible to every other session in the process. Link files are rewritten, so content held
+     * beyond a session is content that may no longer be true -- the same staleness this ticket is about,
+     * one level up from the object length.
+     */
+    @Test
+    public void linkContentIsNotSharedBetweenSessions() {
+        var source = mock(StreamSource.class);
+        var readingSession = new GorSessionCache();
+        var otherSession = new GorSessionCache();
+
+        readingSession.getLinkCache().put(source, "source/versions/generation_1200.gorz");
+
+        assertNull("link content cached by one session must not be visible to another",
+                otherSession.getLinkCache().getIfPresent(source));
+    }
+
+    @Test
+    public void linkCacheEntriesExpire() {
+        var cache = new GorSessionCache().getLinkCache();
+
+        var expiry = cache.policy().expireAfterWrite().orElseThrow(() -> new AssertionError(
+                "session link cache has no write expiry, so link content read once can be served for "
+                        + "the whole lifetime of a long-running session"));
+
+        assertTrue("staleness window must be at most 5 minutes, matching the static link cache",
+                expiry.getExpiresAfter(TimeUnit.MINUTES) <= 5);
+    }
+
+    @Test
+    public void s3MetadataCacheIsSizeBounded() {
+        var cache = new GorSessionCache().getS3MetadataCache();
+
+        var eviction = cache.policy().eviction().orElseThrow(() -> new AssertionError(
+                "session S3 metadata cache is unbounded, so it grows without limit in a "
+                        + "long-running session"));
+
+        eviction.setMaximum(1);
+        cache.put("thebucket/first.gor.link", "meta-1");
+        cache.put("thebucket/second.gor.link", "meta-2");
+        cache.cleanUp();
+
+        assertTrue("cache must evict down to its maximum size", cache.estimatedSize() <= 1);
+    }
+}


### PR DESCRIPTION
[ENGKNOW-3722](https://genedx.atlassian.net/browse/ENGKNOW-3722)

## Problem

GOR queries fail intermittently with `S3 Status Code: 416` (Range Not Satisfiable) when opening versioned `.link` files, each burning ~167 s in retries before hard-failing. 220 occurrences in `clinops-prd` over 14 days (namespace `gregor` 163, `workflows` 57; `gor-worker` 153, `executor` 32, Nextflow tasks 22, `gregor-web` 11).

```
Cannot create iterator for datasource: ref_gregor/genemb/gmb_disease_map.tsv
Cause: Giving up after 167193 milliseconds and 6 retries
Failed to open S3 object: s3://clinops-reference-data/ref/.../gmb_disease_map.tsv.link
byte range bytes=98674-98824 cannot be satisfied from object with content length 98674
(Service: S3, Status Code: 416)
```

`S3Source.open(RequestRange)` clamps every ranged GET to the object length it has cached (`S3Source.java:174`). Object stores have no append — `S3Source.getOutputStream` rejects it outright — so `LinkFile.appendEntry` → `save()` overwrites the whole object, and versioned-link GC (`LinkFile.gcEntries`) shrinks it. The writer calls `invalidateMeta()`, but that only clears its own JVM. Every other pod keeps the pre-rewrite length, requests a range starting at or past the new end, and gets a 416.

The staleness window was effectively unbounded: `gor.s3.meta.cache.session=true` is the default, and the session cache had no expiry and no size bound (`GorSessionCache.java:51`), while gor-worker sessions are long-lived.

`S3RetryHandler.checkIfShouldRetryException` classifies 400/401/403/404 as non-retryable but never 416, so a deterministic failure ran the full ladder — turning a millisecond-wide race into a ~3-minute query outage.

### How the range arises

Worth spelling out, because the numbers look arbitrary. `LinkFile.readLimitedLinkContent` calls `StreamUtils.readString(is, 200000)`, a single 200000-byte read. That exceeds `ExtendedRangeStream`'s 128 kb bookkeeping immediately, so it drains the first request, then reopens at the position reached with double the length:

```
rlen  = max(200000 - 98674, min(max(131072*2, 131072), 8mb)) = 262144
range = [98674, 98674 + 262144)  ->  clamped to the stale 98825  ->  bytes=98674-98824  ->  416
```

Distinct signatures from Loki over 14 days, all showing a cached length larger than the actual:

| requested range | actual content-length | implied cached length |
| --- | --- | --- |
| `bytes=8841-8844` | 8841 | 8845 |
| `bytes=98674-98824` | 98674 | 98825 |
| `bytes=196608-352972` | 43 | ≥ 352973 |
| `bytes=196608-458751` | 34 | ≥ 458752 |

The last two are a link file that shrank from ~350 KB to a 43-byte single-line link — a GC/compaction rewrite — while readers still held the pre-rewrite length.

Unrelated to the chronic 429 throttling on the same bucket. Those do not correlate: Aug 1–3 had 416 bursts on baseline 429 traffic, Aug 8 had ~2.5M 429s and zero 416s. The 429 volume is a real separate problem and still needs its own ticket.

## Fix

**Self-heal, in the source.** On a 416, invalidate the cached metadata, re-read the object length, and reissue the range once. The retry is immediate and local, so it never reaches `RetryStreamSourceWrapper` and costs one HEAD rather than 167 s of sleeps.

Wiring `invalidateMeta()` in as `RetryHandlerBase.perform`'s existing `preRetryOp` was considered — the hook is there and `RetryStreamSourceWrapper` passes `null` for it. Rejected: `invalidateMeta()` is private and not on `StreamSource`, so it needs an interface change, and the hook only fires *after* a sleep.

**Fail fast on what remains.** `S3RetryHandler` and `OCIObjectStorageRetryHandler` now classify 416 as non-retryable. Anything reaching them has already survived the self-heal, so it is a genuinely unsatisfiable range and should fail in milliseconds.

**Bound the session caches.** `s3MetadataCache` gets `maximumSize(10000).expireAfterWrite(5, MINUTES)`, matching the static fallback. This is also what caps the *quiet* half of the bug: a cached length **shorter** than the object makes `ExtendedRangeWrapper` stop at the stale EOF, so `readLimitedLinkContent` returns **truncated** link content with no error at all and resolves the wrong data source. Self-healing 416 fixes only the loud half; the expiry bounds both.

`linkCache` becomes per-session instead of `static`, with the same bounds, so link content read by one session is no longer served to every later one in the process.

**Cache keys.** Keys were `bucket + key` with no separator, so bucket `ab` + key `c` and bucket `a` + key `bc` both produced `abc` — two unrelated objects sharing a cached length, and invalidating one clearing the other. The OCI key was worse: it omitted the namespace entirely, so the same bucket and object name in two namespaces shared one entry.

Applied to `S3Source`, `S3SourceAsync` and `OCIObjectStorageSource`. The OCI variant matches on `BmcException.getStatusCode()`; `S3SourceAsync` catches `RuntimeException` rather than `GorResourceException` because its `openRequest` does not wrap S3 failures — the async branch lets the `CompletionException` through and the sync branch catches only `SdkClientException`.

`linkCache` keeps its `StreamSource`-identity key. Re-keying it on path would switch on real link-content caching and reintroduce exactly the cross-pod staleness class this PR closes, one level up. That belongs in its own ticket.

### Semantics of the self-heal

A 416 means `start >= actual length`, so after the refresh the range is empty in every real case and the read reports EOF — `readString` returns the bytes it already has. If the first chunk and the remainder straddle a rewrite, that content can mix generations; it then fails loudly in link parsing rather than as a 416, which is strictly better than a hard query failure. The cache expiry is what narrows that window. The "object grew between the 416 and the re-HEAD" branch reissues the GET and is covered by its own test.

## Tests

Written test-first; every test was watched failing against the production stack before the fix.

- `UTestS3SourceStaleMetadata` — 416 on a shrunk object reads as EOF; the range is reissued if the refreshed length still covers it; non-416 errors do **not** trigger a metadata refresh (guards against over-broad invalidation); cache keys do not collide across the bucket boundary. Uses the real caller arguments (`262144`), derived from the trace above, not hand-picked ones.
- `UTestS3RetryHandler` / `UTestOCIObjectStorageRetryHandler` — 416 fails on the first attempt; 500 still retries.
- `UTestOCIObjectStorageSourceStaleMetadata` — same three cases plus namespace isolation in the cache key.
- `UTestGorSessionCache` — metadata cache entries expire and the cache is size-bounded; link content cached by one session is not visible to another.
- `ITestS3LinkFileRewrite` — end to end against real S3: write a versioned `.link`, read it through the production wrapper chain to seed the cache, have a **second writer** compact it via the raw `S3Client` (going through `S3Source` would call `invalidateMeta()` and hide the bug, whereas in production the writer is a different pod), then read again. Before the fix this failed with `Status Code: 416` and `Giving up after ... retries`; after, it resolves the compacted entry.

Mutation-checked. The check caught that the OCI 416 branch had been added without a failing test first; that was corrected properly — test written, branch removed, failure observed, branch restored.

- `./gradlew test` — **2595 pass**, 0 fail, 69 skipped (pre-existing)
- `./gradlew :drivers:integrationTest` for S3 + OCI — **88 pass** against real object stores

`drivers` had no mockito; added `testImplementation Testing.mockito.core`.

Not included: `S3SourceAsync.java` is untracked work-in-progress in the working tree, so its fix and its test are held back until that file lands, keeping this PR to the bug. Also fixed in passing: `OCIObjectStorageSource` reported failures as `"Failed to open S3 object"`.

## Impact

Every in-flight reader of a `.link` file was taken down at once whenever that file was rewritten — the bursty shape in the logs, ~6 distinct days in 14. Each failure cost 167 s of retry latency plus a failed query, and the retries held streams and metadata alive longer, marginally widening the race for everyone else.

The quiet half never showed up in the logs at all: a stale-shorter length silently truncated link content and resolved the wrong data source, with no error raised.

Immediate mitigation without this build remains `-Dgor.s3.meta.cache.session=false`, which falls back to the 5-minute-TTL static cache. Do **not** use `-Dgor.s3.meta.cache=false` — disabling caching entirely adds substantial HEAD traffic and would worsen the existing 429 throttling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
