### PR TITLE
fix: default gorRoot to absolute CWD instead of the literal string "./"

### DIFF
--- a/gortools/src/main/java/gorsat/process/GorSessionFactory.java
+++ b/gortools/src/main/java/gorsat/process/GorSessionFactory.java
@@ -25,6 +25,8 @@ package gorsat.process;
 import org.gorpipe.gor.session.GenericFactory;
 import org.gorpipe.gor.session.GorSession;
 
+import java.nio.file.Paths;
+
 public abstract class GorSessionFactory extends GenericFactory<GorSession> {
 
     protected static String updateCommonRoot(String commonRootOpt) {
@@ -33,10 +35,28 @@ public abstract class GorSessionFactory extends GenericFactory<GorSession> {
         }
         if (commonRootOpt != null) {
             if (commonRootOpt.trim().length() == 0) {
-                commonRootOpt = "./";
-            } else if (commonRootOpt.length() > 2 && commonRootOpt.charAt(1) == ':' && !commonRootOpt.endsWith("\\")) { // windows path hack
+                // Default to the process's actual absolute CWD, not the
+                // literal string "./" -- resolving a relative path
+                // against "./" is a no-op in this codebase's URI-based
+                // path resolution (PathUtils.resolve: resolving anything
+                // against a relative base just returns it unchanged),
+                // so anything that needed real anchoring against this
+                // default quietly stayed relative/un-anchored instead
+                // (e.g. PGOR's dictionary-folder write caching -- see
+                // the .gord.link mechanism in GeneralQueryHandler.
+                // getResultsLinkPath, which silently mis-resolves and
+                // fails with a "Resource Error" on a fabricated
+                // version_XXXX.gord name when this root isn't a real,
+                // absolute path). This value is not used for access-
+                // control decisions -- the real enforcement path
+                // (DriverBackedSecureFileReader) always sources its own
+                // root independently -- so this only affects path-
+                // resolution/anchoring correctness, not security scoping.
+                commonRootOpt = Paths.get("").toAbsolutePath().toString();
+            }
+            if (commonRootOpt.length() > 2 && commonRootOpt.charAt(1) == ':' && !commonRootOpt.endsWith("\\")) { // windows path hack
                 commonRootOpt = commonRootOpt + '\\';
-            } else if (!commonRootOpt.endsWith("/")) {
+            } else if (!commonRootOpt.endsWith("/") && !commonRootOpt.endsWith("\\")) {
                 commonRootOpt = commonRootOpt + '/';
             }
         }

--- a/model/src/main/java/org/gorpipe/gor/model/DriverBackedFileReader.java
+++ b/model/src/main/java/org/gorpipe/gor/model/DriverBackedFileReader.java
@@ -65,7 +65,18 @@ public class DriverBackedFileReader extends FileReader {
 
     private static final Logger log = LoggerFactory.getLogger(DriverBackedFileReader.class);
 
-    private static final String DEFAULT_COMMON_ROOT = "./";
+    // The process's actual absolute CWD, not the literal string "./" --
+    // resolving a relative path against "./" is a no-op in this
+    // codebase's URI-based path resolution (PathUtils.resolve), so
+    // anything needing real anchoring against this default (e.g. PGOR's
+    // dictionary-folder write caching -- see GorSessionFactory.
+    // updateCommonRoot()'s own matching fix and docstring) quietly
+    // stayed relative/un-anchored instead. Not used for access-control
+    // decisions -- this class's own validateAccess() is a no-op, and the
+    // real enforcement path (DriverBackedSecureFileReader) always
+    // sources its root independently -- so this only affects path-
+    // resolution/anchoring correctness, not security scoping.
+    private static final String DEFAULT_COMMON_ROOT = PathUtils.markAsFolder(Paths.get("").toAbsolutePath().toString());
 
     final static int GZIP_BUFFER_SIZE = Integer.parseInt(System.getProperty("gor.gzip.buffer.size", "2046"));
 


### PR DESCRIPTION
## Problem

When `-gorroot` is omitted, `GorSessionFactory.updateCommonRoot()` (and `DriverBackedFileReader`'s own matching default) falls back to the literal string `"./"`. Resolving a relative path against `"./"` is a no-op in this codebase's URI-based path resolution (`PathUtils.resolve`: resolving anything against a relative base just returns it unchanged), so any code path that needed real anchoring against this default silently got an un-anchored relative path back instead.

This surfaces concretely in PGOR's dictionary-folder write path: a direct `pgor <sources> | write <target>.gord` (no `-gorroot` given) fails with a spurious Resource Error on a fabricated `version_XXXX.gord` name, even though the write's own underlying computation succeeds. `GeneralQueryHandler.getResultsLinkPath`'s `.gord.link` bookkeeping resolves the write target against this un-anchored root, produces a bare relative string with no directory information, and something downstream mis-resolves it against the wrong base.

Repro (no `-gorroot`, `-cachedir` only — the common case for any caller that doesn't explicitly pass a project root):
```
$ gorpipe "pgor f1.gor f2.gor | write out.gord" -cachedir /tmp/cache
==== Resource Error ====
Command GOR in pipe step #1 has a missing resource:
Input source does not exist: /tmp/cache/xx/out.gord/version_XXXXXXXX.gord
```
Supplying an explicit, absolute `-gorroot` has always worked around this; the actual bug is that the *default* was never a usable root to begin with.

## Fix

Default to the process's actual absolute CWD (`Paths.get("").toAbsolutePath()`) instead of the literal string `"./"`, in both places this default is computed.

## Verified

- Both binaries (this repo, and a downstream fork) rebuilt and confirmed: `pgor <sources> | write <target>.gord` with only `-cachedir` (no `-gorroot`) now succeeds and returns correct data, matching a real caller's actual invocation shape.
- This default is never consulted for access-control decisions: `DriverBackedFileReader.validateAccess()` is a no-op, and the real enforcement path (`DriverBackedSecureFileReader`) always sources its project root independently (raw `PipeOptions.gorRoot()`/deployment-specific env vars, never through `updateCommonRoot()`) — so this change only affects path-resolution/anchoring correctness, not security scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)